### PR TITLE
Expath deps check

### DIFF
--- a/.github/workflows/exist.yml
+++ b/.github/workflows/exist.yml
@@ -6,7 +6,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
-       matrix:
+      fail-fast: false
+      matrix:
          exist-version: [5.2.0, release]
          java-version: [8]  
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build/
+.DS_Store

--- a/build.xml
+++ b/build.xml
@@ -6,6 +6,6 @@
     <property name="build.dir" value="build"/>
     <target name="xar">
         <mkdir dir="${build.dir}"/>
-        <zip basedir="." destfile="${build.dir}/${project.app}-${project.version}.xar" excludes="${build.dir}/* .github/** test/** .gitignore"/>
+        <zip basedir="." destfile="${build.dir}/${project.app}-${project.version}.xar" excludes="${build.dir}/* .github/** .gitignore"/>
     </target>
 </project>

--- a/expath-pkg.xml
+++ b/expath-pkg.xml
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <package xmlns="http://expath.org/ns/pkg" name="https://www.betamasaheft.uni-hamburg.de/BetMasApi" abbrev="BetMasApi" version="1.0.0" spec="1.0">
     <title>API for Beta maṣāḥǝft: Manuscripts of Ethiopia and Eritrea</title>
-    <!-- <dependency package="http://exist-db.org/apps/shared" semver-min="0.9.1"/>
     <dependency package="https://betamasaheft.eu/betmasweb/" semver-min="0.1"/>
-    <dependency package="http://betamasaheft.aai.uni-hamburg.de/gez-en/" semver-min="2.6"/>
-    <dependency package="http://betamasaheft.eu/guidelines" semver-min="0.1"/>
-    <dependency package="http://betamasaheft.aai.uni-hamburg.de/parser/" semver-min="0.5"/> -->
+    <dependency package="https://www.betamasaheft.uni-hamburg.de/BetMas" semver-min="4.0.0"/>
     <dependency processor="http://exist-db.org" semver-min="5.2.0"/>
 </package>

--- a/local/apiSearch.xqm
+++ b/local/apiSearch.xqm
@@ -3,18 +3,27 @@ xquery version "3.1" encoding "UTF-8";
 (:~
  : kwic and simple search from API
  : 
- : @author Pietro Liuzzo 
+ : @author Pietro Liuzzo
+ : @author Duncan Paterson 
  :)
 module namespace apiS = "https://www.betamasaheft.uni-hamburg.de/BetMasApi/apiSearch";
-import module namespace config = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/config" at "xmldb:exist:///db/apps/BetMasWeb/modules/config.xqm";
+
 import module namespace rest = "http://exquery.org/ns/restxq";
-import module namespace kwic = "http://exist-db.org/xquery/kwic" at "resource:org/exist/xquery/lib/kwic.xql";
-import module namespace all="https://www.betamasaheft.uni-hamburg.de/BetMasWeb/all" at "xmldb:exist:///db/apps/BetMasWeb/modules/all.xqm";
-import module namespace log="http://www.betamasaheft.eu/log" at "xmldb:exist:///db/apps/BetMasWeb/modules/log.xqm";
-import module namespace exptit="https://www.betamasaheft.uni-hamburg.de/BetMasWeb/exptit" at "xmldb:exist:///db/apps/BetMasWeb/modules/exptit.xqm";
-(: namespaces of data used :)
+
+
+(: Unused :)
+(: import module namespace kwic = "http://exist-db.org/xquery/kwic" at "resource:org/exist/xquery/lib/kwic.xql";
 import module namespace http="http://expath.org/ns/http-client";
 import module namespace console="http://exist-db.org/xquery/console";
+
+import module namespace config = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/config" at "xmldb:exist:///db/apps/BetMasWeb/modules/config.xqm";
+
+import module namespace all="https://www.betamasaheft.uni-hamburg.de/BetMasWeb/all" at "xmldb:exist:///db/apps/BetMasWeb/modules/all.xqm";
+import module namespace log="http://www.betamasaheft.eu/log" at "xmldb:exist:///db/apps/BetMasWeb/modules/log.xqm";
+import module namespace exptit="https://www.betamasaheft.uni-hamburg.de/BetMasWeb/exptit" at "xmldb:exist:///db/apps/BetMasWeb/modules/exptit.xqm"; :)
+
+(: namespaces of data used :)
+
 
 declare namespace test="http://exist-db.org/xquery/xqsuite";
 declare namespace t = "http://www.tei-c.org/ns/1.0";
@@ -56,7 +65,7 @@ declare
 %rest:query-param("id", "{$id}", "")
 %output:method("json")
 function apiS:titleTest($id) {
-   map{ 'title' : exptit:printTitleID($id) }
+   map{ 'title': exptit:printTitleID($id) }
 };
 
 (:~ returns a map containing the KWIC hits from the evaluation of an xpath containing lucene full text index queries for the API search. :)

--- a/local/apiText.xqm
+++ b/local/apiText.xqm
@@ -3,17 +3,22 @@ xquery version "3.1" encoding "UTF-8";
  : texts from API
  : 
  : @author Pietro Liuzzo 
+ : @author Duncan Paterson 
  :)
-module namespace apiT = "https://www.betamasaheft.uni-hamburg.de/BetMas/apiTexts";
+module namespace apiT = "https://www.betamasaheft.uni-hamburg.de/BetMasApi/apiTexts";
+
+
 import module namespace rest = "http://exquery.org/ns/restxq";
+import module namespace sm = "http://exist-db.org/xquery/securitymanager";
+(: import module namespace http="http://expath.org/ns/http-client"; :)
+
 import module namespace api = "https://www.betamasaheft.uni-hamburg.de/BetMasApi/api"  at "xmldb:exist:///db/apps/BetMasApi/local/rest.xqm";
-import module namespace all="https://www.betamasaheft.uni-hamburg.de/BetMasWeb/all" at "xmldb:exist:///db/apps/BetMasWeb/modules/all.xqm";
+(: import module namespace all="https://www.betamasaheft.uni-hamburg.de/BetMasWeb/all" at "xmldb:exist:///db/apps/BetMasWeb/modules/all.xqm"; :)
 import module namespace log="http://www.betamasaheft.eu/log" at "xmldb:exist:///db/apps/BetMasWeb/modules/log.xqm";
 import module namespace config = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/config" at "xmldb:exist:///db/apps/BetMasWeb/modules/config.xqm";
+
 (: namespaces of data used :)
 declare namespace t = "http://www.tei-c.org/ns/1.0";
-import module namespace http="http://expath.org/ns/http-client";
-
 declare namespace test="http://exist-db.org/xquery/xqsuite";
 
 (: For REST annotations :)

--- a/local/apiTitles.xqm
+++ b/local/apiTitles.xqm
@@ -2,20 +2,24 @@ xquery version "3.1" encoding "UTF-8";
 (:~
  : titles from API
  : 
- : @author Pietro Liuzzo 
+ : @author Pietro Liuzzo
+ : @author Duncan Paterson 
  :)
  
-module namespace apiTit = "https://www.betamasaheft.uni-hamburg.de/BetMas/apiTitles";
+module namespace apiTit = "https://www.betamasaheft.uni-hamburg.de/BetMasApi/apiTitles";
+
 import module namespace rest = "http://exquery.org/ns/restxq";
-import module namespace api = "https://www.betamasaheft.uni-hamburg.de/BetMas/api"  at "xmldb:exist:///db/apps/BetMas/modules/rest.xqm";
+(: import module namespace http="http://expath.org/ns/http-client"; :)
+
+(: import module namespace api = "https://www.betamasaheft.uni-hamburg.de/BetMas/api"  at "xmldb:exist:///db/apps/BetMas/modules/rest.xqm";
 import module namespace all="https://www.betamasaheft.uni-hamburg.de/BetMas/all" at "xmldb:exist:///db/apps/BetMas/modules/all.xqm";
-import module namespace log="http://www.betamasaheft.eu/log" at "xmldb:exist:///db/apps/BetMas/modules/log.xqm";
+import module namespace log="http://www.betamasaheft.eu/log" at "xmldb:exist:///db/apps/BetMas/modules/log.xqm"; :)
+
 import module namespace exptit="https://www.betamasaheft.uni-hamburg.de/BetMas/titles" at "xmldb:exist:///db/apps/BetMas/modules/titles.xqm";
 import module namespace config = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/config" at "xmldb:exist:///db/apps/BetMasWeb/modules/config.xqm";
+
 (: namespaces of data used :)
 declare namespace t = "http://www.tei-c.org/ns/1.0";
-import module namespace http="http://expath.org/ns/http-client";
-
 declare namespace test="http://exist-db.org/xquery/xqsuite";
 
 (: For REST annotations :)
@@ -58,7 +62,7 @@ normalize-space(string-join(exptit:printTitleMainID($id)))
    normalize-space(exptit:printTitleMainID($id))
     else $id
     
-    return map {'title':$titletext}
+    return map {'title': $titletext}
     )
 };
 

--- a/local/apilists.xqm
+++ b/local/apilists.xqm
@@ -3,18 +3,24 @@ xquery version "3.1" encoding "UTF-8";
  : lists from API
  : 
  : @author Pietro Liuzzo 
+ : @author Duncan Paterson
  :)
-module namespace apiL = "https://www.betamasaheft.uni-hamburg.de/BetMas/apiLists";
+module namespace apiL = "https://www.betamasaheft.uni-hamburg.de/BetMasApi/apiLists";
 import module namespace rest = "http://exquery.org/ns/restxq";
-import module namespace all="https://www.betamasaheft.uni-hamburg.de/BetMasWeb/all" at "xmldb:exist:///db/apps/BetMasWeb/modules/all.xqm";
+import module namespace xmldb = "http://exist-db.org/xquery/xmldb";
+import module namespace util = "http://exist-db.org/xquery/dbutil";
+import module namespace sm = "http://exist-db.org/xquery/securitymanager";
+
+(: import module namespace all="https://www.betamasaheft.uni-hamburg.de/BetMasWeb/all" at "xmldb:exist:///db/apps/BetMasWeb/modules/all.xqm"; :)
 import module namespace log="http://www.betamasaheft.eu/log" at "xmldb:exist:///db/apps/BetMasWeb/modules/log.xqm";
 import module namespace exptit="https://www.betamasaheft.uni-hamburg.de/BetMasWeb/exptit" at "xmldb:exist:///db/apps/BetMasWeb/modules/exptit.xqm";
 import module namespace config = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/config" at "xmldb:exist:///db/apps/BetMasWeb/modules/config.xqm";
 import module namespace switch2 = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/switch2"  at "xmldb:exist:///db/apps/BetMasWeb/modules/switch2.xqm";
+
 (: namespaces of data used :)
 declare namespace t = "http://www.tei-c.org/ns/1.0";
 declare namespace json = "http://www.w3.org/2013/XSL/json";
-import module namespace http="http://expath.org/ns/http-client";
+(: import module namespace http="http://expath.org/ns/http-client"; :)
 
 declare namespace test="http://exist-db.org/xquery/xqsuite";
 
@@ -254,10 +260,10 @@ let $log := log:add-log-message('/api/manuscripts/'||$repo||'/list/ids/json', sm
    let $items :=  for $resource in $msfromrepo 
     let $id := string($resource/@xml:id)
     let $title :=  exptit:printTitleID($id)
-    return map {'id' : $id, 'title' : $title}
+    return map {'id': $id, 'title': $title}
     return 
-    map {'items' : $items,
-    'total' : $total}
+    map {'items': $items,
+    'total': $total}
     )
 };
 

--- a/local/apilistsXML.xqm
+++ b/local/apilistsXML.xqm
@@ -2,17 +2,24 @@ xquery version "3.1" encoding "UTF-8";
 (:~
  : lists from API
  : 
- : @author Pietro Liuzzo 
+ : @author Pietro Liuzzo
+ : @author Duncan Paterson 
  :)
-module namespace apiLx = "https://www.betamasaheft.uni-hamburg.de/BetMas/apiLists";
+module namespace apiLx = "https://www.betamasaheft.uni-hamburg.de/BetMasApi/apiListsX";
+
 import module namespace rest = "http://exquery.org/ns/restxq";
-import module namespace all="https://www.betamasaheft.uni-hamburg.de/BetMasWeb/all" at "xmldb:exist:///db/apps/BetMasWeb/modules/all.xqm";
+(: import module namespace http="http://expath.org/ns/http-client"; :)
+import module namespace console="http://exist-db.org/xquery/console";
+import module namespace sm = "http://exist-db.org/xquery/securitymanager";
+import module namespace util = "http://exist-db.org/xquery/dbutil";
+
+
+(: import module namespace all="https://www.betamasaheft.uni-hamburg.de/BetMasWeb/all" at "xmldb:exist:///db/apps/BetMasWeb/modules/all.xqm"; :)
 import module namespace log="http://www.betamasaheft.eu/log" at "xmldb:exist:///db/apps/BetMasWeb/modules/log.xqm";
 import module namespace exptit="https://www.betamasaheft.uni-hamburg.de/BetMasWeb/exptit" at "xmldb:exist:///db/apps/BetMasWeb/modules/exptit.xqm";
 import module namespace config = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/config" at "xmldb:exist:///db/apps/BetMasWeb/modules/config.xqm";
 import module namespace switch2 = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/switch2"  at "xmldb:exist:///db/apps/BetMasWeb/modules/switch2.xqm";
-import module namespace http="http://expath.org/ns/http-client";
-import module namespace console="http://exist-db.org/xquery/console";
+
 
 (: namespaces of data used :)
 declare namespace t = "http://www.tei-c.org/ns/1.0";

--- a/local/attestations.xqm
+++ b/local/attestations.xqm
@@ -5,16 +5,17 @@ xquery version "3.1" encoding "UTF-8";
  : @author Pietro Liuzzo
  : @author Duncan Paterson 
  :)
-module namespace att = "https://www.betamasaheft.uni-hamburg.de/BetMasWebApi/att";
+module namespace att = "https://www.betamasaheft.uni-hamburg.de/BetMasApi/att";
 
 import module namespace rest = "http://exquery.org/ns/restxq";
 
+import module namespace what = "https://www.betamasaheft.uni-hamburg.de/BetMasApi/what" at "xmldb:exist:///db/apps/BetMasApi/local/whatpointshere.xqm";
 
 import module namespace exptit="https://www.betamasaheft.uni-hamburg.de/BetMasWeb/exptit" at "xmldb:exist:///db/apps/BetMasWeb/modules/exptit.xqm";
-(: import module namespace config = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/config" at "xmldb:exist:///db/apps/BetMasWeb/modules/config.xqm"; :)
 import module namespace string = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/string" at "xmldb:exist:///db/apps/BetMasWeb/modules/tei2string.xqm";
+(: import module namespace config = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/config" at "xmldb:exist:///db/apps/BetMasWeb/modules/config.xqm"; :)
 
-import module namespace what = "https://www.betamasaheft.uni-hamburg.de/BetMasApi/what" at "xmldb:exist:///db/apps/BetMasApi/local/whatpointshere.xqm";
+
 
 declare namespace t = "http://www.tei-c.org/ns/1.0";
 

--- a/local/attestations.xqm
+++ b/local/attestations.xqm
@@ -2,13 +2,18 @@ xquery version "3.1" encoding "UTF-8";
 (:~
  : module retrieving a list of attestation of an entity in others.
  : 
- : @author Pietro Liuzzo 
+ : @author Pietro Liuzzo
+ : @author Duncan Paterson 
  :)
-module namespace att = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/att";
+module namespace att = "https://www.betamasaheft.uni-hamburg.de/BetMasWebApi/att";
+
 import module namespace rest = "http://exquery.org/ns/restxq";
+
+
 import module namespace exptit="https://www.betamasaheft.uni-hamburg.de/BetMasWeb/exptit" at "xmldb:exist:///db/apps/BetMasWeb/modules/exptit.xqm";
-import module namespace config = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/config" at "xmldb:exist:///db/apps/BetMasWeb/modules/config.xqm";
+(: import module namespace config = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/config" at "xmldb:exist:///db/apps/BetMasWeb/modules/config.xqm"; :)
 import module namespace string = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/string" at "xmldb:exist:///db/apps/BetMasWeb/modules/tei2string.xqm";
+
 import module namespace what = "https://www.betamasaheft.uni-hamburg.de/BetMasApi/what" at "xmldb:exist:///db/apps/BetMasApi/local/whatpointshere.xqm";
 
 declare namespace t = "http://www.tei-c.org/ns/1.0";
@@ -93,7 +98,7 @@ let $id := if($pers/@ref) then string($pers/@ref) else 'no-id'
               if($pers/@role) 
               then string($pers/@role) 
               else () 
-       return map {'id' : $id ,'name' : $name, 'type' : $thisrole}
+       return map {'id': $id ,'name': $name, 'type': $thisrole}
 return 
 map {'type' : 'persons', 'persons' : $persons}
 )
@@ -109,7 +114,7 @@ let $id := if($place/@ref) then string($place/@ref) else 'no-id'
               if($place/@type) 
               then string($place/@type)
               else () 
-       return map {'id' : $id ,'name' : $name, 'type' : $thistype}
+       return map {'id': $id ,'name': $name, 'type': $thistype}
 return 
 map {'type' : 'places', 'places' : $places}
 )
@@ -136,9 +141,9 @@ let $id := if($term/@key) then string($term/@key) else 'no-id'
               else if (not($term/@key)) then $term/text()
               else exptit:printTitleID($term/@key)
        
-       return map {'id' : $id ,'name' : $name}
+       return map {'id': $id ,'name': $name}
 return 
-map {'type' : 'terms', 'terms' : $terms}
+map {'type': 'terms', 'terms': $terms}
 )
 else ()
 let $occurrences := ($occpers, $occplace, $occwork, $occterm)
@@ -157,13 +162,13 @@ map {'position' : $p,
 
 
 return 
-map {'result' : $atts, 'title' : $titleRoot, 'id' : $MAINID }
+map {'result': $atts, 'title': $titleRoot, 'id': $MAINID }
 
 return
 
 
 ($config:response200Json,
-map {'query' : $id, 'results' : $hits }
+map {'query': $id, 'results': $hits }
 
 )
 };

--- a/local/chojnacki.xqm
+++ b/local/chojnacki.xqm
@@ -2,11 +2,16 @@ xquery version "3.1" encoding "UTF-8";
 (:~
  : module with function called to show content of the archival work of Gnisci at the Vatican Library in BM
  : called by gnisci.js
- : @author Pietro Liuzzo 
+ : @author Pietro Liuzzo
+ : @author Duncan Paterson 
  :)
-module namespace chojnacki = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/chojnacki";
-import module namespace config = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/config" at "xmldb:exist:///db/apps/BetMasWeb/modules/config.xqm";
+
+module namespace chojnacki = "https://www.betamasaheft.uni-hamburg.de/BetMasApi/chojnacki";
+
 import module namespace rest = "http://exquery.org/ns/restxq";
+
+import module namespace config = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/config" at "xmldb:exist:///db/apps/BetMasWeb/modules/config.xqm";
+
 declare namespace marc = "http://www.loc.gov/MARC21/slim";
 
 (: For REST annotations :)
@@ -29,7 +34,7 @@ let $ChojnackItems := for $Choj in $Chojnacki
                                             let $name := string-join($Choj//marc:datafield[@tag="534"]/marc:subfield/text(), ' ')
                                        
                                        return
-  map {'name' : $name, 'link' : $link, 'digvatID' : $DigiVatID, 'segnatura' : $DigiVatSegnatura}
-return if (count($ChojnackItems) ge 1) then map {'total' : count($ChojnackItems), 'ChojnackItems' : $ChojnackItems}
+  map {'name': $name, 'link': $link, 'digvatID': $DigiVatID, 'segnatura': $DigiVatSegnatura}
+return if (count($ChojnackItems) ge 1) then map {'total' : count($ChojnackItems), 'ChojnackItems': $ChojnackItems}
 else if (count($ChojnackItems) eq 1) then map {'total' : 1, 'ChojnackItems' : [$ChojnackItems]}
-else map {'total' : 0, 'info' : 'sorry, there are no related items in the Chojnacki Collection at the Vatic Library.'}};
+else map {'total': 0, 'info': 'sorry, there are no related items in the Chojnacki Collection at the Vatic Library.'}};

--- a/local/clavis.xqm
+++ b/local/clavis.xqm
@@ -3,19 +3,23 @@ xquery version "3.1" encoding "UTF-8";
  : clavis matching related funtions.
  : 
  : @author Pietro Liuzzo 
+ : @author Duncan Paterson
  :)
-module namespace clavis = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/clavis";
+module namespace clavis = "https://www.betamasaheft.uni-hamburg.de/BetMasApi/clavis";
+
 import module namespace rest = "http://exquery.org/ns/restxq";
-import module namespace switch2 = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/switch2"  at "xmldb:exist:///db/apps/BetMasWeb/modules/switch2.xqm";
+import module namespace sm = "http://exist-db.org/xquery/securitymanager";
+(: import module namespace http="http://expath.org/ns/http-client"; :)
+
 import module namespace log="http://www.betamasaheft.eu/log" at "xmldb:exist:///db/apps/BetMasWeb/modules/log.xqm";
 import module namespace exptit="https://www.betamasaheft.uni-hamburg.de/BetMasWeb/exptit" at "xmldb:exist:///db/apps/BetMasWeb/modules/exptit.xqm";
-import module namespace config = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/config" at "xmldb:exist:///db/apps/BetMasWeb/modules/config.xqm";
-import module namespace http="http://expath.org/ns/http-client";
+(: import module namespace config = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/config" at "xmldb:exist:///db/apps/BetMasWeb/modules/config.xqm";
+import module namespace switch2 = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/switch2"  at "xmldb:exist:///db/apps/BetMasWeb/modules/switch2.xqm"; :)
+
 
 (: namespaces of data used :)
 
 declare namespace t = "http://www.tei-c.org/ns/1.0";
-
 declare namespace test="http://exist-db.org/xquery/xqsuite";
 
 (: For REST annotations :)
@@ -62,9 +66,9 @@ se interrogato da titolo da gli id, altrimenti per id da gli altri id e il titol
                     return
                         ( $config:response200Json,
                         map {
-                            "CAe" : $id,
-                            "title" : $title,
-                            "clavis" : $clavisIDS                
+                            "CAe": $id,
+                            "title": $title,
+                            "clavis": $clavisIDS                
                         })
                         
 };

--- a/local/enrichSdCtable.xqm
+++ b/local/enrichSdCtable.xqm
@@ -5,18 +5,22 @@ xquery version "3.1" encoding "UTF-8";
  : by SdCtable.js 
  : 
  : @author Pietro Liuzzo 
+ : @author Duncan Paterson
  :)
-module namespace enrich = "https://www.betamasaheft.uni-hamburg.de/BetMas/enrich";
+module namespace enrich = "https://www.betamasaheft.uni-hamburg.de/BetMasApi/enrich";
+
 import module namespace rest = "http://exquery.org/ns/restxq";
+(: import module namespace http="http://expath.org/ns/http-client"; :)
+
 import module namespace exptit="https://www.betamasaheft.uni-hamburg.de/BetMasWeb/exptit" at "xmldb:exist:///db/apps/BetMasWeb/modules/exptit.xqm";
 import module namespace config = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/config" at "xmldb:exist:///db/apps/BetMasWeb/modules/config.xqm";
-import module namespace string = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/string" at "xmldb:exist:///db/apps/BetMasWeb/modules/tei2string.xqm";
+(: import module namespace string = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/string" at "xmldb:exist:///db/apps/BetMasWeb/modules/tei2string.xqm"; :)
 
 (: namespaces of data used :)
 
 declare namespace t = "http://www.tei-c.org/ns/1.0";
 
-import module namespace http="http://expath.org/ns/http-client";
+
 
 (: For REST annotations :)
 declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";

--- a/local/nodesAndEdges.xqm
+++ b/local/nodesAndEdges.xqm
@@ -2,20 +2,28 @@ xquery version "3.1" encoding "UTF-8";
 (:~
  : returns maps of nodes and edges for a given entity
  : 
- : @author Pietro Liuzzo 
+ : TODO(DP): This looks like it might be better located in BetMasWeb instead of BetMasApi
+ :
+ : @author Pietro Liuzzo
+ : @author Duncan Paterson 
  :)
-module namespace NE = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/NE";
+module namespace NE = "https://www.betamasaheft.uni-hamburg.de/BetMasApi/NE";
+
 import module namespace rest = "http://exquery.org/ns/restxq";
+(: import module namespace util = "http://exist-db.org/xquery/dbutil";
+import module namespace http = "http://expath.org/ns/http-client"; :)
+
 import module namespace switch2 = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/switch2" at "xmldb:exist:///db/apps/BetMasWeb/modules/switch2.xqm";
 import module namespace exptit = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/exptit" at "xmldb:exist:///db/apps/BetMasWeb/modules/exptit.xqm";
 import module namespace config = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/config" at "xmldb:exist:///db/apps/BetMasWeb/modules/config.xqm";
+(: 
 import module namespace string = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/string" at "xmldb:exist:///db/apps/BetMasWeb/modules/tei2string.xqm";
-import module namespace what = "https://www.betamasaheft.uni-hamburg.de/BetMasApi/what" at "xmldb:exist:///db/apps/BetMasApi/local/whatpointshere.xqm";
+import module namespace what = "https://www.betamasaheft.uni-hamburg.de/BetMasApi/what" at "xmldb:exist:///db/apps/BetMasApi/local/whatpointshere.xqm"; :)
 
 (: namespaces of data used :)
 
 declare namespace t = "http://www.tei-c.org/ns/1.0";
-import module namespace http = "http://expath.org/ns/http-client";
+
 (: For REST annotations :)
 declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";
 declare namespace json = "http://www.json.org";

--- a/local/places.xqm
+++ b/local/places.xqm
@@ -6,33 +6,37 @@ xquery version "3.1" encoding "UTF-8";
  : @author Pietro Liuzzo 
  :)
 
-module namespace places = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/places";
+module namespace places = "https://www.betamasaheft.uni-hamburg.de/BetMasApi/places";
+
 import module namespace rest = "http://exquery.org/ns/restxq";
-import module namespace log="http://www.betamasaheft.eu/log" at "xmldb:exist:///db/apps/BetMasWeb/modules/log.xqm";
-import module namespace exptit="https://www.betamasaheft.uni-hamburg.de/BetMasWeb/exptit" at "xmldb:exist:///db/apps/BetMasWeb/modules/exptit.xqm";
-import module namespace coord = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/coord" at "xmldb:exist:///db/apps/BetMasWeb/modules/coordinates.xqm";
-import module namespace editors="https://www.betamasaheft.uni-hamburg.de/BetMasWeb/editors" at "xmldb:exist:///db/apps/BetMasWeb/modules/editors.xqm";
-import module namespace ann = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/ann" at "xmldb:exist:///db/apps/BetMasWeb/modules/annotations.xqm";
-import module namespace all="https://www.betamasaheft.uni-hamburg.de/BetMasWeb/all" at "xmldb:exist:///db/apps/BetMasWeb/modules/all.xqm";
+import module namespace kwic = "http://exist-db.org/xquery/kwic" at "resource:org/exist/xquery/lib/kwic.xql";
+
+
+
 import module namespace config = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/config" at "xmldb:exist:///db/apps/BetMasWeb/modules/config.xqm";
-import module namespace kwic = "http://exist-db.org/xquery/kwic"
-    at "resource:org/exist/xquery/lib/kwic.xql";
+import module namespace ann = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/ann" at "xmldb:exist:///db/apps/BetMasWeb/modules/annotations.xqm";
+import module namespace exptit="https://www.betamasaheft.uni-hamburg.de/BetMasWeb/exptit" at "xmldb:exist:///db/apps/BetMasWeb/modules/exptit.xqm";
+
+(: import module namespace editors="https://www.betamasaheft.uni-hamburg.de/BetMasWeb/editors" at "xmldb:exist:///db/apps/BetMasWeb/modules/editors.xqm";
+import module namespace all="https://www.betamasaheft.uni-hamburg.de/BetMasWeb/all" at "xmldb:exist:///db/apps/BetMasWeb/modules/all.xqm";
+import module namespace coord = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/coord" at "xmldb:exist:///db/apps/BetMasWeb/modules/coordinates.xqm";
+import module namespace log="http://www.betamasaheft.eu/log" at "xmldb:exist:///db/apps/BetMasWeb/modules/log.xqm";
 import module namespace string = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/string" at "xmldb:exist:///db/apps/BetMasWeb/modules/tei2string.xqm";
 import module namespace switch2 = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/switch2" at "xmldb:exist:///db/apps/BetMasWeb/modules/switch2.xqm";   
-import module namespace error = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/error" at "xmldb:exist:///db/apps/BetMasWeb/modules/error.xqm";  
+import module namespace error = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/error" at "xmldb:exist:///db/apps/BetMasWeb/modules/error.xqm";   :)
+
 (: namespaces of data used :)
+
+(: declare namespace s = "http://www.w3.org/2005/xpath-functions"; :)
+declare namespace http = "http://expath.org/ns/http-client";
+
 declare namespace t = "http://www.tei-c.org/ns/1.0";
 declare namespace dcterms = "http://purl.org/dc/terms";
 declare namespace saws = "http://purl.org/saws/ontology";
 declare namespace cmd = "http://www.clarin.eu/cmd/";
 declare namespace skos = "http://www.w3.org/2004/02/skos/core#";
 declare namespace rdf = "http://www.w3.org/1999/02/22-rdf-syntax-ns#";
-declare namespace s = "http://www.w3.org/2005/xpath-functions";
 declare namespace sparql = "http://www.w3.org/2005/sparql-results#";
-(: For REST annotations :)
-(:http requests:)
-declare namespace http = "http://expath.org/ns/http-client";
-
 
 declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";
 declare namespace json = "http://www.json.org";
@@ -101,8 +105,8 @@ declare function places:JSONfile($item as node(), $id as xs:string){
 let $regions := if($item//t:region[@ref])   then  for $region in $item//t:region[@ref] return ann:getannotationbody($region/@ref)   else ()
         let $settlements := if($item//t:settlement[@ref]) then for $settl in $item//t:settlement[@ref] return ann:getannotationbody($settl/@ref) else ()
         let $connects := ($regions, $settlements, "https://pleiades.stoa.org/places/39274")
-        let $creators := for $c in config:distinct-values($item//t:revisionDesc/t:change[contains(., 'created')]/@who) return map {"name" : editors:editorKey($c)}
-        let $contributors := for $c in config:distinct-values($item//t:revisionDesc/t:change/@who) return map {"name" : editors:editorKey($c)}
+        let $creators := for $c in config:distinct-values($item//t:revisionDesc/t:change[contains(., 'created')]/@who) return map {"name": editors:editorKey($c)}
+        let $contributors := for $c in config:distinct-values($item//t:revisionDesc/t:change/@who) return map {"name": editors:editorKey($c)}
         let $periods := if($item//t:state) then for $c in $item//t:state[@type eq 'existence']/@ref return exptit:printTitleID($c) else ()
         let $names := for $name in $item//t:place/t:placeName 
         let $nID := $name/@xml:id

--- a/local/quotations.xqm
+++ b/local/quotations.xqm
@@ -1,14 +1,18 @@
-            
 xquery version "3.1" encoding "UTF-8";
 (:~
  : module to retrive quotations of  a given specific passage
  : 
  : @author Pietro Liuzzo 
+ : @author Duncan Paterson
  :)
-module namespace quotations = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/quotatoins";
+module namespace quotations = "https://www.betamasaheft.uni-hamburg.de/BetMasApi/quotations";
+
 import module namespace rest = "http://exquery.org/ns/restxq";
+
 import module namespace exptit="https://www.betamasaheft.uni-hamburg.de/BetMasWeb/exptit" at "xmldb:exist:///db/apps/BetMasWeb/modules/exptit.xqm";
-import module namespace config = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/config" at "xmldb:exist:///db/apps/BetMasWeb/modules/config.xqm";
+(: import module namespace config = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/config" at "xmldb:exist:///db/apps/BetMasWeb/modules/config.xqm"; :)
+
+
 declare namespace t = "http://www.tei-c.org/ns/1.0";
 
 (: For REST annotations :)
@@ -32,10 +36,10 @@ let $thispassage :=
 for $quote in $quotations[t:ref[contains(substring-after(@cRef, concat($text, ':')), $passage)]]
                                             let $id := string(root($quote)/t:TEI/@xml:id) 
                                           let $titlesource := exptit:printTitleID($id)
-                                           let $source := map {'id' : $id, 'title' : $titlesource} 
+                                           let $source := map {'id': $id, 'title': $titlesource} 
                                             let $t := $quote/t:quote/text()
                                             let $r := string($quote/t:ref/@cRef)
                                         return 
-                                        map {'text' : $t, 'source' : $source, 'ref' : $r}
-return if (count($thispassage) ge 1) then map {'total' : count($thispassage), 'quotations' : [$thispassage]} else map {'total' : 0, 'info' : 'sorry, there are no marked up quotations of this passage'}
+                                        map {'text': $t, 'source': $source, 'ref': $r}
+return if (count($thispassage) ge 1) then map {'total': count($thispassage), 'quotations': [$thispassage]} else map {'total': 0, 'info': 'sorry, there are no marked up quotations of this passage'}
 };

--- a/local/rest.xqm
+++ b/local/rest.xqm
@@ -5,22 +5,25 @@ xquery version "3.1" encoding "UTF-8";
  : @author Pietro Liuzzo 
  :)
 module namespace api = "https://www.betamasaheft.uni-hamburg.de/BetMasApi/api";
+
 import module namespace rest = "http://exquery.org/ns/restxq";
+(: import module namespace http="http://expath.org/ns/http-client";
+import module namespace kwic = "http://exist-db.org/xquery/kwic" at "resource:org/exist/xquery/lib/kwic.xql"; :)
+
+import module namespace config = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/config" at "xmldb:exist:///db/apps/BetMasWeb/modules/config.xqm";
+import module namespace viewItem = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/viewItem" at "xmldb:exist:///db/apps/BetMasWeb/modules/viewItem.xqm";
+
+(: import module namespace dts="https://www.betamasaheft.uni-hamburg.de/BetMasApi/dts" at "xmldb:exist:///db/apps/BetMasApi/specifications/dts.xqm";
+
 import module namespace switch2 = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/switch2"  at "xmldb:exist:///db/apps/BetMasWeb/modules/switch2.xqm";
 import module namespace log="http://www.betamasaheft.eu/log" at "xmldb:exist:///db/apps/BetMasWeb/modules/log.xqm";
 import module namespace all="https://www.betamasaheft.uni-hamburg.de/BetMasWeb/all" at "xmldb:exist:///db/apps/BetMasWeb/modules/all.xqm";
-import module namespace dts="https://www.betamasaheft.uni-hamburg.de/BetMas/dts" at "xmldb:exist:///db/apps/BetMasApi/specifications/dts.xqm";
 import module namespace editors="https://www.betamasaheft.uni-hamburg.de/BetMasWeb/editors" at "xmldb:exist:///db/apps/BetMasWeb/modules/editors.xqm";
 import module namespace wiki="https://www.betamasaheft.uni-hamburg.de/BetMasWeb/wiki" at "xmldb:exist:///db/apps/BetMasWeb/modules/wikitable.xqm";
 import module namespace exptit="https://www.betamasaheft.uni-hamburg.de/BetMasWeb/exptit" at "xmldb:exist:///db/apps/BetMasWeb/modules/exptit.xqm";
-import module namespace config = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/config" at "xmldb:exist:///db/apps/BetMasWeb/modules/config.xqm";
-import module namespace viewItem = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/viewItem" at "xmldb:exist:///db/apps/BetMasWeb/modules/viewItem.xqm";
-import module namespace kwic = "http://exist-db.org/xquery/kwic"
-    at "resource:org/exist/xquery/lib/kwic.xql"; 
-
 
 import module namespace fusekisparql = 'https://www.betamasaheft.uni-hamburg.de/BetMasWeb/sparqlfuseki' at "xmldb:exist:///db/apps/BetMasWeb/fuseki/fuseki.xqm";
-import module namespace string = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/string" at "xmldb:exist:///db/apps/BetMasWeb/modules/tei2string.xqm";
+import module namespace string = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/string" at "xmldb:exist:///db/apps/BetMasWeb/modules/tei2string.xqm"; :)
 
 (: namespaces of data used :)
 declare namespace test="http://exist-db.org/xquery/xqsuite";
@@ -30,10 +33,9 @@ declare namespace saws = "http://purl.org/saws/ontology";
 declare namespace cmd = "http://www.clarin.eu/cmd/";
 declare namespace skos = "http://www.w3.org/2004/02/skos/core#";
 declare namespace rdf = "http://www.w3.org/1999/02/22-rdf-syntax-ns#";
-declare namespace s = "http://www.w3.org/2005/xpath-functions";
+(: declare namespace s = "http://www.w3.org/2005/xpath-functions"; :)
 declare namespace sr = "http://www.w3.org/2005/sparql-results#";
 
-import module namespace http="http://expath.org/ns/http-client";
 
 (: For REST annotations :)
 declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";
@@ -156,7 +158,7 @@ function api:loadmsItems($mainid as xs:string, $msItem as xs:string*)
 let $msItemID := replace($msItem, '-', '.')
 let $msItem := $item/id($msItemID)
 let $items := for $ms in $msItem/t:msItem return api:msItem($mainid, $ms)
-return map{'msitems':$items}
+return map{'msitems': $items}
 
 };
    

--- a/local/roles.xqm
+++ b/local/roles.xqm
@@ -4,24 +4,32 @@ xquery version "3.1" encoding "UTF-8";
  : module with all the main functions which can be called by the API.
  : 
  : @author Pietro Liuzzo 
+ : @author Duncan Paterson
  :)
-module namespace roles = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/roles";
+module namespace roles = "https://www.betamasaheft.uni-hamburg.de/BetMasApi/roles";
+
 import module namespace rest = "http://exquery.org/ns/restxq";
+import module namespace kwic = "http://exist-db.org/xquery/kwic" at "resource:org/exist/xquery/lib/kwic.xql";
+import module namespace sm = "http://exist-db.org/xquery/securitymanager";
+import module namespace ft ="http://exist-db.org/xquery/lucene";
+
+(: import module namespace http="http://expath.org/ns/http-client"; :)
+
 import module namespace log="http://www.betamasaheft.eu/log" at "xmldb:exist:///db/apps/BetMasWeb/modules/log.xqm";
 import module namespace exptit="https://www.betamasaheft.uni-hamburg.de/BetMasWeb/exptit" at "xmldb:exist:///db/apps/BetMasWeb/modules/exptit.xqm";
 import module namespace config = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/config" at "xmldb:exist:///db/apps/BetMasWeb/modules/config.xqm";
-import module namespace kwic = "http://exist-db.org/xquery/kwic" at "resource:org/exist/xquery/lib/kwic.xql";
+
 (: namespaces of data used :)
 declare namespace t = "http://www.tei-c.org/ns/1.0";
-import module namespace http="http://expath.org/ns/http-client";
-
 declare namespace test="http://exist-db.org/xquery/xqsuite";
 
 (: For REST annotations :)
 declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";
 
 
-(:~ given a role, search other attestations of it and print the persName around them and related infos :) 
+(:~ given a role, search other attestations of it and print the persName around them and related infos 
+ : TODO(DP): refactor to use structural index via fn:id() instead of relying on range index
+ :) 
 declare
 %rest:GET
 %rest:path("/api/RoleAttestations")
@@ -111,9 +119,9 @@ let $hits := for $pwl in $path
             
         return
             map {
-                'pwl' : $ID,
-                'title' : exptit:printTitleID($ID),
-                'hits' : count($pwl)
+                'pwl': $ID,
+                'title': exptit:printTitleID($ID),
+                'hits': count($pwl)
                     }
 
 return 

--- a/local/search.xqm
+++ b/local/search.xqm
@@ -2,10 +2,15 @@ xquery version "3.1" encoding "UTF-8";
 (:~
  : module with all the main functions which can be called by the API.
  :
+ : TODO(DP): duplicate file in BetMas collection
+ : 
  : @author Pietro Liuzzo 
+ : @author Duncan Paterson
  :)
-module namespace restSearch = "https://www.betamasaheft.uni-hamburg.de/BetMas/restSearch";
+module namespace restSearch = "https://www.betamasaheft.uni-hamburg.de/BetMasApi/restSearch";
+
 import module namespace rest = "http://exquery.org/ns/restxq";
+
 import module namespace apprest = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/apprest" at "xmldb:exist:///db/apps/BetMasWeb/modules/apprest.xqm";
 
 declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";

--- a/local/sharedKeywords.xqm
+++ b/local/sharedKeywords.xqm
@@ -4,18 +4,22 @@ xquery version "3.1" encoding "UTF-8";
  : 
  : @author Pietro Liuzzo 
  :)
-module namespace SK = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/SK";
+module namespace SK = "https://www.betamasaheft.uni-hamburg.de/BetMasApi/SK";
+
 import module namespace rest = "http://exquery.org/ns/restxq";
-import module namespace switch2 = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/switch2"  at "xmldb:exist:///db/apps/BetMasWeb/modules/switch2.xqm";
+import module namespace sm = "http://exist-db.org/xquery/securitymanager";
+import module namespace util = "http://exist-db.org/xquery/dbutil";
+(: import module namespace http="http://expath.org/ns/http-client"; :)
+
 import module namespace log="http://www.betamasaheft.eu/log" at "xmldb:exist:///db/apps/BetMasWeb/modules/log.xqm";
 import module namespace exptit="https://www.betamasaheft.uni-hamburg.de/BetMasWeb/exptit" at "xmldb:exist:///db/apps/BetMasWeb/modules/exptit.xqm";
-import module namespace config = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/config" at "xmldb:exist:///db/apps/BetMasWeb/modules/config.xqm";
+
+(: import module namespace switch2 = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/switch2"  at "xmldb:exist:///db/apps/BetMasWeb/modules/switch2.xqm";
+import module namespace config = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/config" at "xmldb:exist:///db/apps/BetMasWeb/modules/config.xqm"; :)
 
 (: namespaces of data used :)
 
 declare namespace t = "http://www.tei-c.org/ns/1.0";
-
-import module namespace http="http://expath.org/ns/http-client";
 
 (: For REST annotations :)
 declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";
@@ -73,14 +77,14 @@ let $hits := for $hit in $query
                
           return
             map {
-                'id' : $id,
-                'title' : $title
+                'id': $id,
+                'title': $title
                     }
 
 return 
 ($config:response200Json,
 map {
-'hits' : $hits,
-'total' : $total
+'hits': $hits,
+'total': $total
 })
 };

--- a/local/sparqlRest.xqm
+++ b/local/sparqlRest.xqm
@@ -3,15 +3,21 @@ xquery version "3.1" encoding "UTF-8";
  : module with all the main functions which can be called by the API.
  : 
  : @author Pietro Liuzzo 
+ : @author Duncan Paterson
  :)
 module namespace apisparql = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/apisparql";
+
 import module namespace rest = "http://exquery.org/ns/restxq";
-import module namespace exptit="https://www.betamasaheft.uni-hamburg.de/BetMasWeb/exptit" at "xmldb:exist:///db/apps/BetMasWeb/modules/exptit.xqm";
+import module namespace console="http://exist-db.org/xquery/console";
+(: import module namespace http="http://expath.org/ns/http-client"; :)
+
 import module namespace config = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/config" at "xmldb:exist:///db/apps/BetMasWeb/modules/config.xqm";
-import module namespace editors="https://www.betamasaheft.uni-hamburg.de/BetMasWeb/editors" at "xmldb:exist:///db/apps/BetMasWeb/modules/editors.xqm";
 import module namespace fusekisparql = 'https://www.betamasaheft.uni-hamburg.de/BetMasWeb/sparqlfuseki' at "xmldb:exist:///db/apps/BetMasWeb/fuseki/fuseki.xqm";
-import module namespace string = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/string" at "xmldb:exist:///db/apps/BetMasWeb/modules/tei2string.xqm";
-    import module namespace console="http://exist-db.org/xquery/console";
+
+(: import module namespace exptit="https://www.betamasaheft.uni-hamburg.de/BetMasWeb/exptit" at "xmldb:exist:///db/apps/BetMasWeb/modules/exptit.xqm";
+import module namespace editors="https://www.betamasaheft.uni-hamburg.de/BetMasWeb/editors" at "xmldb:exist:///db/apps/BetMasWeb/modules/editors.xqm";
+import module namespace string = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/string" at "xmldb:exist:///db/apps/BetMasWeb/modules/tei2string.xqm"; :)
+
 (: namespaces of data used :)
 declare namespace test="http://exist-db.org/xquery/xqsuite";
 declare namespace t = "http://www.tei-c.org/ns/1.0";
@@ -20,10 +26,11 @@ declare namespace saws = "http://purl.org/saws/ontology";
 declare namespace cmd = "http://www.clarin.eu/cmd/";
 declare namespace skos = "http://www.w3.org/2004/02/skos/core#";
 declare namespace rdf = "http://www.w3.org/1999/02/22-rdf-syntax-ns#";
-declare namespace s = "http://www.w3.org/2005/xpath-functions";
 declare namespace sr = "http://www.w3.org/2005/sparql-results#";
 
-import module namespace http="http://expath.org/ns/http-client";
+(: declare namespace s = "http://www.w3.org/2005/xpath-functions"; :)
+
+
 
 (: For REST annotations :)
 declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";
@@ -193,7 +200,7 @@ declare function apisparql:xml2json($nodes as node()*){
                                                          let $thepairs := for $pair in $property 
                                                                               let $type := if($pair/@rdf:resource) then 'uri'  else if($pair/element()) then 'bnode' else 'literal'
                                                                               let $value := if($pair/@rdf:resource) then string($pair/@rdf:resource) else if ($pair/element()) then ('another node') else normalize-space($pair/text())
-                                                                              let $pairmap :=  map {'type' : $type, 'value' : $value}
+                                                                              let $pairmap :=  map {'type': $type, 'value': $value}
                                                                               let $withxmllang := if($pair/@xml:lang) then map:put($pairmap, 'xml:lang', string($pair/@xml:lang)) else $pairmap
                                                                               let $withtype := if($pair/@*:datatype) then map:put($withxmllang, 'datatype', string($pair/@*:datatype)) else $withxmllang
                                                                                  return 
@@ -222,7 +229,7 @@ declare function apisparql:xml2json($nodes as node()*){
         return 
       map:merge( for $x in $node/sr:binding 
        let $binding := apisparql:xml2json($x/node()) 
-       return map{$x!@*:name : $binding}
+       return map{$x!@*:name: $binding}
        )
        case element(sr:bnode)
        return
@@ -237,7 +244,7 @@ declare function apisparql:xml2json($nodes as node()*){
        $withtype
        case element(sr:literal)
        return
-       let $literal :=  map {'type' : 'literal', 'value' : $node/text()}
+       let $literal :=  map {'type': 'literal', 'value': $node/text()}
         let $withxmllang := if($node/@xml:lang) then map:put($literal, 'xml:lang', $node/@xml:lang) else $literal
        let $withtype := if($node/@*:datatype) then map:put($withxmllang, 'datatype', $node/@*:datatype) else $withxmllang
        return 

--- a/local/whatpointshere.xqm
+++ b/local/whatpointshere.xqm
@@ -2,7 +2,10 @@ xquery version "3.1" encoding "UTF-8";
 (:~
  : module with all the main functions which can be called by the API.
  : 
+ : TODO(DP): Figure out what it really does, this is copy pasta from elsewhere. 
+ :
  : @author Pietro Liuzzo 
+ : @author Duncan Paterson
  :)
 module namespace what = "https://www.betamasaheft.uni-hamburg.de/BetMasApi/what";
 

--- a/local/wordCount.xqm
+++ b/local/wordCount.xqm
@@ -3,11 +3,16 @@ xquery version "3.1" encoding "UTF-8";
  : module returning word count for a single piece of text in a manuscript.
  : 
  : @author Pietro Liuzzo 
+ : @author Duncan Paterson
  :)
-module namespace WC = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/WC";
+module namespace WC = "https://www.betamasaheft.uni-hamburg.de/BetMasApi/WC";
+
 import module namespace rest = "http://exquery.org/ns/restxq";
+
 import module namespace config = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/config" at "xmldb:exist:///db/apps/BetMasWeb/modules/config.xqm";
+
 declare namespace t = "http://www.tei-c.org/ns/1.0";
+
 (: For REST annotations :)
 declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";
 declare namespace json = "http://www.json.org";

--- a/repo.xml
+++ b/repo.xml
@@ -9,5 +9,6 @@
     <type>application</type>
     <target>BetMasApi</target>
     <finish/>
+    <!-- TODO(DP): reconsider the permissions set-up see https://github.com/BetaMasaheft/Documentation/issues/2222 -->
     <permissions user="Pietro" group="dba" mode="rw-rw-r--"/>
 </meta>

--- a/specifications/dts.xqm
+++ b/specifications/dts.xqm
@@ -14,7 +14,7 @@ xquery version "3.1" encoding "UTF-8";
 : urn:dts:betmasMS:Zotemberg1234:BLorient12314
  :)
 
-module namespace dts="https://www.betamasaheft.uni-hamburg.de/BetMas/dts";
+module namespace dts="https://www.betamasaheft.uni-hamburg.de/BetMasApi/dts";
 
 declare namespace output="http://www.w3.org/2010/xslt-xquery-serialization";
 declare namespace t="http://www.tei-c.org/ns/1.0";

--- a/specifications/dtsXML.xqm
+++ b/specifications/dtsXML.xqm
@@ -2,20 +2,27 @@ xquery version "3.1" encoding "UTF-8";
 (:~
  : early test implementation of the https://github.com/distributed-text-services
  : SERVER
- : @author Pietro Liuzzo 
+ : @author Pietro Liuzzo
+ : @author Duncan Paterson 
 :)
-module namespace dtsXML="https://www.betamasaheft.uni-hamburg.de/BetMas/dtsXML";
+module namespace dtsXML="https://www.betamasaheft.uni-hamburg.de/BetMasApi/dtsXML";
 
-declare namespace output="http://www.w3.org/2010/xslt-xquery-serialization";
-declare namespace t="http://www.tei-c.org/ns/1.0";
-declare namespace exist = "http://exist.sourceforge.net/NS/exist";
-declare namespace s = "http://www.w3.org/2005/xpath-functions";
-declare namespace http = "http://expath.org/ns/http-client";
-declare namespace json = "http://www.json.org";
 import module namespace rest = "http://exquery.org/ns/restxq";
+import module namespace xmldb = "http://exist-db.org/xquery/xmldb";
+import module namespace sm = "http://exist-db.org/xquery/securitymanager";
+
 import module namespace log="http://www.betamasaheft.eu/log" at "xmldb:exist:///db/apps/BetMasWeb/modules/log.xqm";
 import module namespace exptit="https://www.betamasaheft.uni-hamburg.de/BetMasWeb/exptit" at "xmldb:exist:///db/apps/BetMasWeb/modules/exptit.xqm";
 import module namespace config="https://www.betamasaheft.uni-hamburg.de/BetMasWeb/config" at "xmldb:exist:///db/apps/BetMasWeb/modules/config.xqm";
+
+
+declare namespace t="http://www.tei-c.org/ns/1.0";
+declare namespace exist = "http://exist.sourceforge.net/NS/exist";
+declare namespace http = "http://expath.org/ns/http-client";
+declare namespace json = "http://www.json.org";
+(: declare namespace s = "http://www.w3.org/2005/xpath-functions"; :)
+
+declare namespace output="http://www.w3.org/2010/xslt-xquery-serialization";
 declare option output:method "json";
 declare option output:indent "yes";
 

--- a/specifications/iiif.xqm
+++ b/specifications/iiif.xqm
@@ -3,20 +3,28 @@ xquery version "3.1" encoding "UTF-8";
  : implementation of the http://iiif.io/api/presentation/2.1/ 
  : for images of manuscripts stored in betamasaheft server. extracts manifest, sequence, canvas from the tei data
  : 
+ : TODO(DP): Check relationship to https://www.betamasaheft.uni-hamburg.de/BetMas/iiifviewer
+ : 
  : @author Pietro Liuzzo 
+ : @author Duncan Paterson
  :)
-module namespace iiif = "https://www.betamasaheft.uni-hamburg.de/BetMas/iiif";
+module namespace iiif = "https://www.betamasaheft.uni-hamburg.de/BetMasApi/iiif";
+
 import module namespace rest = "http://exquery.org/ns/restxq";
+(: import module namespace console = "http://exist-db.org/xquery/console";
+import module namespace kwic = "http://exist-db.org/xquery/kwic" at "resource:org/exist/xquery/lib/kwic.xql"; :)
+
+
+
+import module namespace config = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/config" at "xmldb:exist:///db/apps/BetMasWeb/modules/config.xqm";
+import module namespace locus = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/locus" at "xmldb:exist:///db/apps/BetMasWeb/modules/locus.xqm";
+
+(: import module namespace api="https://www.betamasaheft.uni-hamburg.de/BetMasApi/api" at "xmldb:exist:///db/apps/BetMasApi/local/rest.xqm";
 import module namespace log="http://www.betamasaheft.eu/log" at "xmldb:exist:///db/apps/BetMasWeb/modules/log.xqm";
 import module namespace all="https://www.betamasaheft.uni-hamburg.de/BetMasWeb/all" at "xmldb:exist:///db/apps/BetMasWeb/modules/all.xqm";
 import module namespace exptit="https://www.betamasaheft.uni-hamburg.de/BetMasWeb/exptit" at "xmldb:exist:///db/apps/BetMasWeb/modules/exptit.xqm";
-import module namespace api="https://www.betamasaheft.uni-hamburg.de/BetMasApi/api" at "xmldb:exist:///db/apps/BetMasApi/local/rest.xqm";
-import module namespace config = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/config" at "xmldb:exist:///db/apps/BetMasWeb/modules/config.xqm";
-import module namespace kwic = "http://exist-db.org/xquery/kwic"
-    at "resource:org/exist/xquery/lib/kwic.xql";
-import module namespace string = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/string" at "xmldb:exist:///db/apps/BetMasWeb/modules/tei2string.xqm";
-import module namespace console = "http://exist-db.org/xquery/console";
-import module namespace locus = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/locus" at "xmldb:exist:///db/apps/BetMasWeb/modules/locus.xqm";
+import module namespace string = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/string" at "xmldb:exist:///db/apps/BetMasWeb/modules/tei2string.xqm"; :)
+
 (: namespaces of data used :)
 declare namespace t = "http://www.tei-c.org/ns/1.0";
 declare namespace dcterms = "http://purl.org/dc/terms";
@@ -24,8 +32,9 @@ declare namespace saws = "http://purl.org/saws/ontology";
 declare namespace cmd = "http://www.clarin.eu/cmd/";
 declare namespace skos = "http://www.w3.org/2004/02/skos/core#";
 declare namespace rdf = "http://www.w3.org/1999/02/22-rdf-syntax-ns#";
-declare namespace s = "http://www.w3.org/2005/xpath-functions";
 declare namespace sparql = "http://www.w3.org/2005/sparql-results#";
+(: declare namespace s = "http://www.w3.org/2005/xpath-functions"; :)
+
 
 (: For REST annotations :)
 declare namespace http = "http://expath.org/ns/http-client";

--- a/specifications/json.xqm
+++ b/specifications/json.xqm
@@ -1,31 +1,40 @@
 xquery version "3.1" encoding "UTF-8";
-(: 
-implementation of 
-https://jsonapi.org/format/ 
-for 
-https://github.com/BetaMasaheft/Documentation/issues/1109
-:)
-module namespace jsonapi="https://www.betamasaheft.uni-hamburg.de/BetMas/jsonapi";
+(:~ JsonApi for … ?
+ : @see https://jsonapi.org/format/ 
+ : @see https://github.com/BetaMasaheft/Documentation/issues/1109
+ : 
+ : @author Pietro Liuzzo 
+ : @author Duncan Paterson
+ :)
+ 
+module namespace jsonapi="https://www.betamasaheft.uni-hamburg.de/BetMasApi/jsonapi";
+
+import module namespace rest = "http://exquery.org/ns/restxq";
+
+(: import module namespace functx="http://www.functx.com";
+import module namespace sparql="http://exist-db.org/xquery/sparql" at "java:org.exist.xquery.modules.rdf.SparqlModule";
+import module namespace what = "https://www.betamasaheft.uni-hamburg.de/BetMasApi/what" at "xmldb:exist:///db/apps/BetMasApi/local/whatpointshere.xqm"; :)
+
+import module namespace switch2 = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/switch2" at "xmldb:exist:///db/apps/BetMasWeb/modules/switch2.xqm";
+import module namespace editors = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/editors" at "xmldb:exist:///db/apps/BetMasWeb/modules/editors.xqm";
+import module namespace exptit="https://www.betamasaheft.uni-hamburg.de/BetMasWeb/exptit" at "xmldb:exist:///db/apps/BetMasWeb/modules/exptit.xqm";
+
+(: import module namespace log="http://www.betamasaheft.eu/log" at "xmldb:exist:///db/apps/BetMasWeb/modules/log.xqm";
+import module namespace config="https://www.betamasaheft.uni-hamburg.de/BetMasWeb/config" at "xmldb:exist:///db/apps/BetMasWeb/modules/config.xqm"; :)
+
 
 declare namespace output="http://www.w3.org/2010/xslt-xquery-serialization";
 declare namespace t="http://www.tei-c.org/ns/1.0";
 declare namespace exist = "http://exist.sourceforge.net/NS/exist";
-declare namespace s = "http://www.w3.org/2005/xpath-functions";
+
 declare namespace http = "http://expath.org/ns/http-client";
 declare namespace json = "http://www.json.org";
 declare namespace cx ="http://interedition.eu/collatex/ns/1.0";
 declare namespace sr="http://www.w3.org/2005/sparql-results#";
 declare namespace test="http://exist-db.org/xquery/xqsuite";
+(: declare namespace s = "http://www.w3.org/2005/xpath-functions"; :)
 
-import module namespace functx="http://www.functx.com";
-import module namespace rest = "http://exquery.org/ns/restxq";
-import module namespace log="http://www.betamasaheft.eu/log" at "xmldb:exist:///db/apps/BetMasWeb/modules/log.xqm";
-import module namespace exptit="https://www.betamasaheft.uni-hamburg.de/BetMasWeb/exptit" at "xmldb:exist:///db/apps/BetMasWeb/modules/exptit.xqm";
-import module namespace config="https://www.betamasaheft.uni-hamburg.de/BetMasWeb/config" at "xmldb:exist:///db/apps/BetMasWeb/modules/config.xqm";
-import module namespace sparql="http://exist-db.org/xquery/sparql" at "java:org.exist.xquery.modules.rdf.SparqlModule";
-import module namespace switch2 = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/switch2" at "xmldb:exist:///db/apps/BetMasWeb/modules/switch2.xqm";
-import module namespace editors = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/editors" at "xmldb:exist:///db/apps/BetMasWeb/modules/editors.xqm";
-import module namespace what = "https://www.betamasaheft.uni-hamburg.de/BetMasApi/what" at "xmldb:exist:///db/apps/BetMasApi/local/whatpointshere.xqm";
+
 
 declare variable $jsonapi:response200Json := <rest:response>
             <http:response

--- a/specifications/persistentdts.xqm
+++ b/specifications/persistentdts.xqm
@@ -24,27 +24,31 @@ xquery version "3.1" encoding "UTF-8";
 : urn:dts:betmasMS:Zotemberg1234:BLorient12314
  :)
 
-module namespace persdts="https://www.betamasaheft.uni-hamburg.de/BetMasWeb/persdts";
+module namespace persdts="https://www.betamasaheft.uni-hamburg.de/BetMasApi/persdts";
+
+import module namespace rest = "http://exquery.org/ns/restxq";
+(: import module namespace functx="http://www.functx.com"; :)
+
+import module namespace config="https://www.betamasaheft.uni-hamburg.de/BetMasWeb/config" at "xmldb:exist:///db/apps/BetMasWeb/modules/config.xqm";
+import module namespace exptit="https://www.betamasaheft.uni-hamburg.de/BetMasWeb/exptit" at "xmldb:exist:///db/apps/BetMasWeb/modules/exptit.xqm";
+
+
+(: import module namespace log="http://www.betamasaheft.eu/log" at "xmldb:exist:///db/apps/BetMasWeb/modules/log.xqm";
+import module namespace fusekisparql = 'https://www.betamasaheft.uni-hamburg.de/BetMasWeb/sparqlfuseki' at "xmldb:exist:///db/apps/BetMasWeb/fuseki/fuseki.xqm";
+import module namespace string = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/string" at "xmldb:exist:///db/apps/BetMasWeb/modules/tei2string.xqm";
+import module namespace editors = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/editors" at "xmldb:exist:///db/apps/BetMasWeb/modules/editors.xqm";
+import module namespace dts="https://www.betamasaheft.uni-hamburg.de/BetMasWeb/dts" at "xmldb:exist:///db/apps/BetMasWeb/modules/dts.xqm"; :)
 
 declare namespace output="http://www.w3.org/2010/xslt-xquery-serialization";
 declare namespace t="http://www.tei-c.org/ns/1.0";
 declare namespace exist = "http://exist.sourceforge.net/NS/exist";
-declare namespace s = "http://www.w3.org/2005/xpath-functions";
 declare namespace http = "http://expath.org/ns/http-client";
 declare namespace json = "http://www.json.org";
 declare namespace cx ="http://interedition.eu/collatex/ns/1.0";
 declare namespace sr="http://www.w3.org/2005/sparql-results#";
 declare namespace test="http://exist-db.org/xquery/xqsuite";
+(: declare namespace s = "http://www.w3.org/2005/xpath-functions"; :)
 
-import module namespace functx="http://www.functx.com";
-import module namespace rest = "http://exquery.org/ns/restxq";
-import module namespace log="http://www.betamasaheft.eu/log" at "xmldb:exist:///db/apps/BetMasWeb/modules/log.xqm";
-import module namespace exptit="https://www.betamasaheft.uni-hamburg.de/BetMasWeb/exptit" at "xmldb:exist:///db/apps/BetMasWeb/modules/exptit.xqm";
-import module namespace config="https://www.betamasaheft.uni-hamburg.de/BetMasWeb/config" at "xmldb:exist:///db/apps/BetMasWeb/modules/config.xqm";
-import module namespace fusekisparql = 'https://www.betamasaheft.uni-hamburg.de/BetMasWeb/sparqlfuseki' at "xmldb:exist:///db/apps/BetMasWeb/fuseki/fuseki.xqm";
-import module namespace string = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/string" at "xmldb:exist:///db/apps/BetMasWeb/modules/tei2string.xqm";
-import module namespace editors = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/editors" at "xmldb:exist:///db/apps/BetMasWeb/modules/editors.xqm";
-import module namespace dts="https://www.betamasaheft.uni-hamburg.de/BetMasWeb/dts" at "xmldb:exist:///db/apps/BetMasWeb/modules/dts.xqm";
 
 
   declare variable $persdts:collection-rootMS  := collection($config:data-rootMS);   

--- a/specifications/persistentiiif.xqm
+++ b/specifications/persistentiiif.xqm
@@ -1,23 +1,28 @@
-
 xquery version "3.1" encoding "UTF-8";
 (:~
  : implementation of the http://iiif.io/api/presentation/2.1/ 
  : for images of manuscripts stored in betamasaheft server. extracts manifest, sequence, canvas from the tei data
  : 
  : @author Pietro Liuzzo 
+ : @author Duncan Paterson
  :)
- module namespace persiiif = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/persiiif";
-import module namespace iiif = "https://www.betamasaheft.uni-hamburg.de/BetMas/iiif"at "xmldb:exist:///db/apps/BetMasApi/specifications/iiif.xqm";
+module namespace persiiif = "https://www.betamasaheft.uni-hamburg.de/BetMasApi/persiiif";
+
 import module namespace rest = "http://exquery.org/ns/restxq";
+import module namespace sm = "http://exist-db.org/xquery/securitymanager";
+(: import module namespace console = "http://exist-db.org/xquery/console"; :)
+
+import module namespace iiif = "https://www.betamasaheft.uni-hamburg.de/BetMasApi/iiif"at "xmldb:exist:///db/apps/BetMasApi/specifications/iiif.xqm";
+(: import module namespace api="https://www.betamasaheft.uni-hamburg.de/BetMasApi/api" at "xmldb:exist:///db/apps/BetMasApi/local/rest.xqm"; :)
+
 import module namespace log="http://www.betamasaheft.eu/log" at "xmldb:exist:///db/apps/BetMasWeb/modules/log.xqm";
-import module namespace all="https://www.betamasaheft.uni-hamburg.de/BetMasWeb/all" at "xmldb:exist:///db/apps/BetMasWeb/modules/all.xqm";
-import module namespace exptit="https://www.betamasaheft.uni-hamburg.de/BetMasWeb/exptit" at "xmldb:exist:///db/apps/BetMasWeb/modules/exptit.xqm";
-import module namespace api="https://www.betamasaheft.uni-hamburg.de/BetMasApi/api" at "xmldb:exist:///db/apps/BetMasApi/local/rest.xqm";
 import module namespace config = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/config" at "xmldb:exist:///db/apps/BetMasWeb/modules/config.xqm";
-import module namespace kwic = "http://exist-db.org/xquery/kwic"
-    at "resource:org/exist/xquery/lib/kwic.xql";
-import module namespace string = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/string" at "xmldb:exist:///db/apps/BetMasWeb/modules/tei2string.xqm";
-import module namespace console = "http://exist-db.org/xquery/console";
+import module namespace exptit="https://www.betamasaheft.uni-hamburg.de/BetMasWeb/exptit" at "xmldb:exist:///db/apps/BetMasWeb/modules/exptit.xqm";
+
+(: import module namespace all="https://www.betamasaheft.uni-hamburg.de/BetMasWeb/all" at "xmldb:exist:///db/apps/BetMasWeb/modules/all.xqm";
+import module namespace kwic = "http://exist-db.org/xquery/kwic" at "resource:org/exist/xquery/lib/kwic.xql";
+import module namespace string = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/string" at "xmldb:exist:///db/apps/BetMasWeb/modules/tei2string.xqm"; :)
+
 (: namespaces of data used :)
 declare namespace t = "http://www.tei-c.org/ns/1.0";
 (: For REST annotations :)

--- a/specifications/shine.xqm
+++ b/specifications/shine.xqm
@@ -1,26 +1,42 @@
 xquery version "3.1" encoding "UTF-8";
-module namespace shine="https://www.betamasaheft.uni-hamburg.de/BetMas/shine";
+
+(:~
+ : …on you crazy diamond ?
+ : 
+ : @author Pietro Liuzzo 
+ : @author Duncan Paterson
+ :)
+
+module namespace shine="https://www.betamasaheft.uni-hamburg.de/BetMasApi/shine";
+
+import module namespace rest = "http://exquery.org/ns/restxq";
+(: import module namespace functx="http://www.functx.com";
+import module namespace sparql="http://exist-db.org/xquery/sparql" at "java:org.exist.xquery.modules.rdf.SparqlModule"; :)
+
+
+import module namespace config="https://www.betamasaheft.uni-hamburg.de/BetMasWeb/config" at "xmldb:exist:///db/apps/BetMasWeb/modules/config.xqm";
+
+
+
+(: import module namespace log="http://www.betamasaheft.eu/log" at "xmldb:exist:///db/apps/BetMasWeb/modules/log.xqm";
+import module namespace exptit="https://www.betamasaheft.uni-hamburg.de/BetMasWeb/exptit" at "xmldb:exist:///db/apps/BetMasWeb/modules/exptit.xqm";
+import module namespace string = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/string" at "xmldb:exist:///db/apps/BetMasWeb/modules/tei2string.xqm";
+import module namespace switch2 = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/switch2" at "xmldb:exist:///db/apps/BetMasWeb/modules/switch2.xqm";
+import module namespace editors = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/editors" at "xmldb:exist:///db/apps/BetMasWeb/modules/editors.xqm";
+import module namespace dtslib="https://www.betamasaheft.uni-hamburg.de/BetMasWeb/dtslib" at "xmldb:exist:///db/apps/BetMasWeb/modules/dtslib.xqm"; :)
+
 
 declare namespace output="http://www.w3.org/2010/xslt-xquery-serialization";
 declare namespace t="http://www.tei-c.org/ns/1.0";
 declare namespace exist = "http://exist.sourceforge.net/NS/exist";
-declare namespace s = "http://www.w3.org/2005/xpath-functions";
 declare namespace http = "http://expath.org/ns/http-client";
 declare namespace json = "http://www.json.org";
 declare namespace cx ="http://interedition.eu/collatex/ns/1.0";
 declare namespace sr="http://www.w3.org/2005/sparql-results#";
 declare namespace test="http://exist-db.org/xquery/xqsuite";
 
-import module namespace functx="http://www.functx.com";
-import module namespace rest = "http://exquery.org/ns/restxq";
-import module namespace log="http://www.betamasaheft.eu/log" at "xmldb:exist:///db/apps/BetMasWeb/modules/log.xqm";
-import module namespace exptit="https://www.betamasaheft.uni-hamburg.de/BetMasWeb/exptit" at "xmldb:exist:///db/apps/BetMasWeb/modules/exptit.xqm";
-import module namespace config="https://www.betamasaheft.uni-hamburg.de/BetMasWeb/config" at "xmldb:exist:///db/apps/BetMasWeb/modules/config.xqm";
-import module namespace sparql="http://exist-db.org/xquery/sparql" at "java:org.exist.xquery.modules.rdf.SparqlModule";
-import module namespace string = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/string" at "xmldb:exist:///db/apps/BetMasWeb/modules/tei2string.xqm";
-import module namespace switch2 = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/switch2" at "xmldb:exist:///db/apps/BetMasWeb/modules/switch2.xqm";
-import module namespace editors = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/editors" at "xmldb:exist:///db/apps/BetMasWeb/modules/editors.xqm";
-import module namespace dtslib="https://www.betamasaheft.uni-hamburg.de/BetMasWeb/dtslib" at "xmldb:exist:///db/apps/BetMasWeb/modules/dtslib.xqm";
+(: declare namespace s = "http://www.w3.org/2005/xpath-functions"; :)
+
 
 declare variable $shine:TU := collection($config:data-rootW)//t:div[@type='edition'][descendant::t:ab[text()]] ;
 declare variable $shine:MS := collection($config:data-rootMS)//t:div[@type='edition'][descendant::t:ab[text()]] ;

--- a/specifications/void.xqm
+++ b/specifications/void.xqm
@@ -4,17 +4,22 @@ xquery version "3.1" encoding "UTF-8";
  : @author Pietro Liuzzo 
  :)
 
-module namespace void = "https://www.betamasaheft.uni-hamburg.de/BetMas/void";
+module namespace void = "https://www.betamasaheft.uni-hamburg.de/BetMasApi/void";
+
+import module namespace rest = "http://exquery.org/ns/restxq";
+
+(: import module namespace api="https://www.betamasaheft.uni-hamburg.de/BetMasApi/api" at "xmldb:exist:///db/apps/BetMasApi/local/rest.xqm"; :)
+
 import module namespace switch2 = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/switch2"  at "xmldb:exist:///db/apps/BetMasWeb/modules/switch2.xqm";
 import module namespace config = "https://www.betamasaheft.uni-hamburg.de/BetMasWeb/config" at "xmldb:exist:///db/apps/BetMasWeb/modules/config.xqm";
 import module namespace exptit="https://www.betamasaheft.uni-hamburg.de/BetMasWeb/exptit" at "xmldb:exist:///db/apps/BetMasWeb/modules/exptit.xqm";
-import module namespace api="https://www.betamasaheft.uni-hamburg.de/BetMasApi/api" at "xmldb:exist:///db/apps/BetMasApi/local/rest.xqm";
 
 declare namespace t = "http://www.tei-c.org/ns/1.0";
 declare namespace http = "http://expath.org/ns/http-client";
 declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";
 declare namespace json = "http://www.json.org";
 declare namespace test="http://exist-db.org/xquery/xqsuite";
+
 
 declare variable $void:response200turtle := <rest:response>
             <http:response

--- a/test/test-runner.xq
+++ b/test/test-runner.xq
@@ -1,0 +1,23 @@
+xquery version "3.1";
+
+(:~ This library runs the XQSuite unit tests for the BetMasApi.
+ : TODO(DP): untested scaffold  here to collect pre-existing test code
+ :
+ : @author Duncan Paterson
+ : @version 1.0.0-Alpha
+ : @see http://www.exist-db.org/exist/apps/doc/xqsuite
+ :)
+import module namespace test = "http://exist-db.org/xquery/xqsuite" at "resource:org/exist/xquery/lib/xqsuite/xqsuite.xql";
+import module namespace api = "https://www.betamasaheft.uni-hamburg.de/BetMasApi/api" at '../local/rest.xqm';
+
+declare namespace output="http://www.w3.org/2010/xslt-xquery-serialization";
+declare option output:method "json";
+declare option output:media-type "application/json";
+
+
+test:suite(
+  (
+    inspect:module-functions(xs:anyURI("rest.xqm")),
+    inspect:module-functions(xs:anyURI("local/rest.xqm"))
+  )
+)

--- a/test/test-runner.xq
+++ b/test/test-runner.xq
@@ -8,7 +8,11 @@ xquery version "3.1";
  : @see http://www.exist-db.org/exist/apps/doc/xqsuite
  :)
 import module namespace test = "http://exist-db.org/xquery/xqsuite" at "resource:org/exist/xquery/lib/xqsuite/xqsuite.xql";
+import module namespace apiT = "https://www.betamasaheft.uni-hamburg.de/BetMasApi/apiTexts" at '../local/apiText.xqm';
+import module namespace att = "https://www.betamasaheft.uni-hamburg.de/BetMasWebApi/att" at '../local/attestations.xqm';
 import module namespace api = "https://www.betamasaheft.uni-hamburg.de/BetMasApi/api" at '../local/rest.xqm';
+import module namespace roles = "https://www.betamasaheft.uni-hamburg.de/BetMasApi/roles" at '../local/roles.xqm';
+import module namespace WC = "https://www.betamasaheft.uni-hamburg.de/BetMasApi/WC" at '../local/wordCount.xqm';
 
 declare namespace output="http://www.w3.org/2010/xslt-xquery-serialization";
 declare option output:method "json";
@@ -17,7 +21,10 @@ declare option output:media-type "application/json";
 
 test:suite(
   (
+    inspect:module-functions(xs:anyURI("apiText.xqm")),
+    inspect:module-functions(xs:anyURI("attestations.xqm")),
     inspect:module-functions(xs:anyURI("rest.xqm")),
-    inspect:module-functions(xs:anyURI("local/rest.xqm"))
+    inspect:module-functions(xs:anyURI("roles.xqm")),
+    inspect:module-functions(xs:anyURI("wordCount.xqm"))
   )
 )

--- a/test/test-runner.xq
+++ b/test/test-runner.xq
@@ -9,7 +9,7 @@ xquery version "3.1";
  :)
 import module namespace test = "http://exist-db.org/xquery/xqsuite" at "resource:org/exist/xquery/lib/xqsuite/xqsuite.xql";
 import module namespace apiT = "https://www.betamasaheft.uni-hamburg.de/BetMasApi/apiTexts" at '../local/apiText.xqm';
-import module namespace att = "https://www.betamasaheft.uni-hamburg.de/BetMasWebApi/att" at '../local/attestations.xqm';
+import module namespace att = "https://www.betamasaheft.uni-hamburg.de/BetMasApi/att" at '../local/attestations.xqm';
 import module namespace api = "https://www.betamasaheft.uni-hamburg.de/BetMasApi/api" at '../local/rest.xqm';
 import module namespace roles = "https://www.betamasaheft.uni-hamburg.de/BetMasApi/roles" at '../local/roles.xqm';
 import module namespace WC = "https://www.betamasaheft.uni-hamburg.de/BetMasApi/WC" at '../local/wordCount.xqm';


### PR DESCRIPTION
Implements declaring actual dependencies. Findings:
- sparql module declared but not used
- two modules from BetMasWeb are declared on practically every xq file, idea behind the separation still unclear
- found some tests 
- lots of unecessary imports
- one `viewer.xqm` from `betmas` needs further investigation
- installs on 5.2. but not on 6.x
- fair number of duplicates identified, still need to diff this repo against, production.   
- This repo contains code copied from BetMas, before going live we need to run a proper diff again


TODO:
- i think some import statements can be replaced with simple namespace declarations
- namespace declarations are not marked by linter if unused there is more cleanup potential there. 

see https://github.com/BetaMasaheft/Documentation/issues/2176
see https://github.com/BetaMasaheft/Documentation/issues/2180
see https://github.com/BetaMasaheft/Documentation/issues/2178

close #4