### PR TITLE
ci(smoke): migrate to the shared org install-smoke.yml workflow

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,16 +1,15 @@
 name: Install smoke
 
-# Two signals, deliberately separate jobs:
-#   1. compile - does `ant` produce a xar at all? Fast, fails loud on its own.
-#   2. smoke   - install that xar (and its dependencies, via xst's own
-#      registry-based resolution) into a clean duncdrum/existdb:release-slim
-#      with no data, then run the jinks-template checks.
+# Pure install smoke: does this package autodeploy cleanly into a bare
+# eXist? The full stack + Cypress integration lane lives in exist.yml.
 #
-# The full stack + Cypress integration lane lives in exist.yml, which pulls
-# the published BetMas app image (real corpus included) instead.
-
-# Scoped like exist.yml: push+pull_request both matching a PR branch would
-# otherwise double-trigger this workflow for the same commit.
+# BetMasWeb and BetMasService aren't standalone registry-published repos
+# yet, so a sibling job builds them from source and hands the xars over as
+# an artifact. monex (this repo's own console-importing modules, plus
+# BetMasWeb's controller.xql) and functx (BetMasWeb's dtslib.xqm) are
+# installed explicitly ahead of them - neither is a declared dependency of
+# anything installed here yet (BetaMasaheft/BetMasWeb#35 fixes that on
+# BetMasWeb's side; drop functx here once it merges).
 on:
   push:
     branches: [master, main]
@@ -18,56 +17,15 @@ on:
     branches: [master, main]
 
 jobs:
-  compile:
+  build-extra-xars:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-
       - name: Install Java
         uses: actions/setup-java@v5
         with:
           distribution: "temurin"
-          java-version: 21
+          java-version: "8"
 
-      - run: ant
-
-      - uses: actions/upload-artifact@v7
-        with:
-          name: betmasapi-xar
-          path: build/*.xar
-          retention-days: 1
-
-  smoke:
-    needs: compile
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-
-      - uses: ./.github/actions/setup-test-toolchain
-
-      - name: Download this repo's xar built by the compile job
-        uses: actions/download-artifact@v8
-        with:
-          name: betmasapi-xar
-          path: build
-
-      - name: Install Java
-        uses: actions/setup-java@v5
-        with:
-          distribution: "temurin"
-          java-version: 21
-
-      # BetMasWeb/BetMasService aren't expath-registry packages, so they're
-      # built from source here; monex and functx aren't declared as a
-      # dependency of anything installed below (BetMasWeb needs both at
-      # runtime - functx via a direct module import, monex for eXist's
-      # built-in console module - without either declaring it in
-      # expath-pkg.xml), so xst's --registry resolution never reaches them
-      # on its own and they're fetched explicitly instead.
-      #
-      # The two builds don't depend on each other's output (only *install*
-      # order matters, below), so they run in the background concurrently
-      # instead of one after the other.
       - name: Build BetMasWeb and BetMasService from source
         run: |
           git clone --depth 1 https://github.com/BetaMasaheft/BetMasWeb.git /tmp/BetMasWeb &
@@ -78,77 +36,53 @@ jobs:
           wait "$web"
           ant -f /tmp/BetMasWeb/build.xml
           wait "$service"
+          mkdir extra-xars
+          cp /tmp/BetMas/db/apps/BetMasService/build/*.xar extra-xars/01-BetMasService.xar
+          cp /tmp/BetMasWeb/build/*.xar extra-xars/02-BetMasWeb.xar
 
-      - name: Start a clean eXist instance
+      # BetMasWeb's post-install creates /db/apps/expanded/<coll>/new,
+      # which needs the parent collection to already exist - true via the
+      # real corpus, not here. Temporary: drop once
+      # BetaMasaheft/BetMasWeb#35 merges (post-install.xq becomes
+      # self-healing there).
+      - name: Build a placeholder-collections package
         run: |
-          docker run -dit -p 8080:8080 --name exist --rm \
-            --health-interval=2s --health-start-period=8s \
-            duncdrum/existdb:release-slim
+          mkdir -p placeholder-pkg
+          cat > placeholder-pkg/expath-pkg.xml <<'EOF'
+          <?xml version="1.0" encoding="UTF-8"?>
+          <package xmlns="http://expath.org/ns/pkg" name="https://betamasaheft.eu/betmasapi-smoke-placeholders" abbrev="betmasapi-smoke-placeholders" version="0.1" spec="1.0">
+              <title>Smoke-test-only placeholder collections</title>
+          </package>
+          EOF
+          cat > placeholder-pkg/repo.xml <<'EOF'
+          <?xml version="1.0" encoding="UTF-8"?>
+          <meta xmlns="http://exist-db.org/xquery/repo">
+              <description>Smoke-test-only placeholder collections</description>
+              <type>application</type>
+              <target>betmasapi-smoke-placeholders</target>
+              <finish>post-install.xq</finish>
+          </meta>
+          EOF
+          cat > placeholder-pkg/post-install.xq <<'EOF'
+          xquery version "3.1";
+          declare variable $target external;
+          if (xmldb:collection-available('/db/apps/expanded')) then () else xmldb:create-collection('/db/apps', 'expanded'),
+          for $c in ('authority-files', 'manuscripts', 'institutions', 'narratives', 'persons', 'places', 'studies', 'works')
+          return if (xmldb:collection-available('/db/apps/expanded/' || $c)) then () else xmldb:create-collection('/db/apps/expanded', $c)
+          EOF
+          (cd placeholder-pkg && zip -r ../extra-xars/00-placeholder-collections.xar .)
 
-      - name: Wait for server to start
-        uses: ./.github/actions/wait-for-exist
-        timeout-minutes: 2
+      - uses: actions/upload-artifact@v7
+        with:
+          name: betmasapi-extra-xars
+          path: extra-xars/*.xar
+          retention-days: 1
 
-      # Install order matters: BetMasWeb's post-install calls BetMasService's
-      # RestXQ registration script directly (not a declared dependency, just
-      # how it's written), so BetMasService has to exist first. shared-
-      # resources and roaster ARE declared dependencies, so --registry
-      # resolves them automatically instead of being fetched by hand.
-      - name: Install packages
-        env:
-          EXISTDB_SERVER: http://localhost:8080
-          EXISTDB_USER: admin
-          EXISTDB_PASS: ""
-        run: |
-          REGISTRY=https://exist-db.org/exist/apps/public-repo/public
-          install_from_url() {
-            curl -fsSL -o /tmp/pkg.xar "$1"
-            npx xst package install local-files /tmp/pkg.xar
-          }
-
-          install_from_url "$REGISTRY/monex-4.2.4.xar"
-          install_from_url "https://exist-db.org/exist/apps/public-repo/find?abbrev=functx&processor=http://exist-db.org&semver-min=1.0"
-
-          npx xst package install local-files /tmp/BetMas/db/apps/BetMasService/build/*.xar --registry "$REGISTRY"
-
-          # BetMasWeb's post-install creates /db/apps/expanded/<coll>/new,
-          # which needs the parent collection to already exist - normally
-          # true because the full corpus (betmas-data's expanded.xar)
-          # already provides it; here there's no data, so create the
-          # placeholders it expects first, in one round trip.
-          npx xst execute '
-            let $root := if (xmldb:collection-available("/db/apps/expanded")) then () else xmldb:create-collection("/db/apps", "expanded")
-            for $c in ("authority-files", "manuscripts", "institutions", "narratives", "persons", "places", "studies", "works")
-            return if (xmldb:collection-available("/db/apps/expanded/" || $c)) then () else xmldb:create-collection("/db/apps/expanded", $c)
-          ' >/dev/null
-
-          npx xst package install local-files /tmp/BetMasWeb/build/*.xar --registry "$REGISTRY"
-          npx xst package install local-files build/*.xar --registry "$REGISTRY"
-
-      # Automatic RestXQ discovery (RestXqTrigger, fired on every document
-      # store during install) isn't reliable here - BetMas works around the
-      # same thing with an explicit, hand-maintained module list
-      # (BetMasService/modules/registerRESTXQ.xql). Do the same but scoped
-      # to this repo's own modules and built from the actual directory
-      # listing instead of a list that goes stale.
-      - name: Register this repo's RestXQ routes
-        env:
-          EXISTDB_SERVER: http://localhost:8080
-          EXISTDB_USER: admin
-          EXISTDB_PASS: ""
-        run: |
-          npx xst execute '
-            count(
-              for $dir in ("local", "specifications")
-              for $m in xmldb:get-child-resources("/db/apps/BetMasApi/" || $dir)[ends-with(., ".xqm")]
-              let $uri := xs:anyURI("/db/apps/BetMasApi/" || $dir || "/" || $m)
-              return (exrest:deregister-module($uri), exrest:register-module($uri))
-            )
-          '
-
-      - name: Run smoke test
-        run: bats --tap test/connect_spec.bats
-
-      - name: Show logs on failure
-        if: failure()
-        run: docker logs exist
+  smoke:
+    needs: build-extra-xars
+    uses: BetaMasaheft/.github/.github/workflows/install-smoke.yml@main
+    with:
+      extra-packages: |
+        monex
+        functx
+      extra-xars-artifact: betmasapi-extra-xars


### PR DESCRIPTION
## Summary

Replaces this repo's bespoke `compile`+`smoke` job pair with `BetaMasaheft/.github`'s `install-smoke.yml` reusable workflow - the same pattern already proven in `BetaMasaheft/BetMasWeb`#35. `monex` + `functx` fit `extra-packages`; `BetMasWeb` + `BetMasService` (built from source, neither is a standalone registry-published repo yet) fit `extra-xars-artifact` via a sibling `build-extra-xars` job.

### Dropped entirely: "Register this repo's RestXQ routes"

Verified empirically before removing it, not assumed: installed this repo end-to-end in a bare container without ever running that step, then probed routes directly (`/api/void`, `/api/iiif/collections`, `/api/manuscripts/list/xml` - including the modules that import the `console` module, the ones most likely to be affected) - all dispatched correctly (200/400/500 as expected app-level responses, never 404/405), zero `ERROR`/`FATAL` in the container's full lifetime.

Root cause: this repo has zero `%rest:path` annotations left anywhere - routing is fully Roaster/`api.json`-driven since #20, and `exrest:register-module`/`deregister-module` are APIs for the old RestXQ annotation system this repo no longer uses. Almost certainly a pre-Roaster-migration leftover that never got cleaned up.

### Still temporary: the placeholder-collections xar

`BetMasWeb`'s `post-install.xq` requires `/db/apps/expanded/<coll>` to already exist (true via the real corpus, not in a bare smoke-test container), so a synthetic placeholder xar still creates them here - same mechanism `BetMasWeb`'s own `smoke.yml` used before `BetMasWeb`#35 fixed it at the source. Drop this step (and `functx` from `extra-packages`) once `BetMasWeb`#35 merges.

## Test plan

- [x] Verified locally end-to-end against a bare `duncdrum/existdb:release-slim` container, replicating the new workflow's exact sequence (`monex`+`functx` from registry, extra-xars in sorted order, this repo's own package)
- [x] Shared `install-smoke.bats`: 7/8 (8th only fails due to a local port remap for testing convenience - confirmed the server was actually reachable via direct `curl`)
- [x] Zero `ERROR`/`FATAL` in the full container lifetime
- [x] This repo's own routes (`void`, `iiif/collections`, `manuscripts/list/xml`) all 200 without the removed registration step
- [ ] Real CI run - opening as draft to confirm
