### PR TITLE
test(apilistsXML): cover /api/works/list/xml

### DIFF
--- a/test/cypress/e2e/apilistsXML.cy.js
+++ b/test/cypress/e2e/apilistsXML.cy.js
@@ -5,3 +5,14 @@ it("GET /api/manuscripts/list/xml", () => {
 		expect(res.status, `/api/manuscripts/list/xml responded with ${res.status}`).to.be.lessThan(500);
 	});
 });
+
+// see #41: no coverage existed for the "works" collection specifically -
+// Documentation#2122 reported this one broken on production
+it("GET /api/works/list/xml", () => {
+	cy.request({ url: "/api/works/list/xml", failOnStatusCode: false }).then((res) => {
+		expect(res.status, `/api/works/list/xml responded with ${res.status}`).to.eq(200);
+		const total = Cypress.$(res.body).find("total").text();
+		expect(Number(total), "total should be a positive number").to.be.greaterThan(0);
+		expect(Cypress.$(res.body).find("item").length, "at least one item").to.be.greaterThan(0);
+	});
+});


### PR DESCRIPTION
## Summary
Adds a test for `/api/works/list/xml` - the `apilistsXML.cy.js` suite only covered `manuscripts`, not `works`. `Documentation`#2122 reported this endpoint broken on production; verified working against the container (200, real `<items>`/`<total>` content), but nothing would have caught a regression until now.

Closes #41.

## Test plan
- [x] Ran locally against a container built from `docker-compose.yml` (`release-expanded` base): both tests in the spec pass.