### PR TITLE
docs: mark places:json as BetMasWeb's Roaster/crossapp contract

### DIFF
--- a/local/places.xqm
+++ b/local/places.xqm
@@ -248,11 +248,13 @@ declare function places:JSONfile($item as node(), $id as xs:string) {
 };
 
 (:~
- : Public contract: BetMasWeb's controller.xql forwards bare {id}.json requests
- : here (path hardcoded on that side as /apps/BetMasApi/api/geoJson/places/{id},
- : guarded by xmldb:collection-available("/db/apps/BetMasApi") so a deployment
- : without this package degrades gracefully - see BetMasWeb#36). Renaming or
- : moving this route requires a matching update in BetMasWeb's controller.xql.
+ : Public contract: BetMasWeb's own Roaster router resolves bare {id}.json
+ : requests to this function (operationId "places:json", registered in
+ : BetMasWeb's routes.json/api.json) via modules/crossapp.xqm's dynamic
+ : cross-app lookup, since this package is an optional add-on not installed
+ : in BetMasWeb's own standalone/test image - see BetMasWeb#36. Renaming
+ : this function, its namespace, or its collection path requires a matching
+ : update to the registry entry in BetMasWeb's modules/crossapp.xqm.
  :)
 declare function places:json($request as map(*)) {
 	let $id as xs:string* := $request?parameters?id

--- a/local/places.xqm
+++ b/local/places.xqm
@@ -137,7 +137,11 @@ declare function places:JSONfile($item as node(), $id as xs:string) {
 		for $latlng in tokenize($item//t:geo[@rend eq "polygon"], "\n")
 		return replace(normalize-space($latlng), " ", ",")
 	) else
-		for $c in tokenize(coord:invertCoord(coord:getCoords($id)), ",")
+		(: coord:getCoords branches on a full BMurl-prefixed uri, not a bare
+		xml:id - passing $id here always misses every branch and falls through
+		to an external-gazetteer-ref lookup that can't match it either, so this
+		always produced XPath NaN (BetMasApi#47). :)
+		for $c in tokenize(coord:invertCoord(coord:getCoords($uri)), ",")
 		return number($c)
 	return map {
 		"@context":

--- a/local/places.xqm
+++ b/local/places.xqm
@@ -247,6 +247,13 @@ declare function places:JSONfile($item as node(), $id as xs:string) {
 	}
 };
 
+(:~
+ : Public contract: BetMasWeb's controller.xql forwards bare {id}.json requests
+ : here (path hardcoded on that side as /apps/BetMasApi/api/geoJson/places/{id},
+ : guarded by xmldb:collection-available("/db/apps/BetMasApi") so a deployment
+ : without this package degrades gracefully - see BetMasWeb#36). Renaming or
+ : moving this route requires a matching update in BetMasWeb's controller.xql.
+ :)
 declare function places:json($request as map(*)) {
 	let $id as xs:string* := $request?parameters?id
 	return if (starts-with($id, "LOC") or starts-with($id, "INS") or starts-with($id, "ETH")) then (

--- a/test/cypress/e2e/places.cy.js
+++ b/test/cypress/e2e/places.cy.js
@@ -1,6 +1,28 @@
 // generated from local/places.xqm
 
-it("GET /api/geoJson/places/LIT1367Exodus", () => {
+// LIT1367Exodus is a work id, not a LOC/INS/ETH place id - places:json
+// returns an empty body for it (still 200), so this only proved the route
+// doesn't error, not that it produces real geoJSON. Use the LOC5374Rome
+// fixture and assert on content - this is the route BetMasWeb's
+// controller.xql forwards {id}.json requests to (BetMasWeb#36).
+//
+// Asserting on res.body as a string, not a parsed object: places:JSONfile
+// calls coord:getCoords($id) with the bare xml:id, but getCoords expects a
+// full BMurl-prefixed uri to match its own branches (LOC5374Rome has no
+// <geo> but does have @sameAs="wd:Q220" - getCoords never reaches that
+// branch with a bare id) - coordinates/bbox/reprPoint come back XPath NaN,
+// which JSON-serializes as the bare token NaN, so the response isn't valid
+// JSON and cy.request leaves res.body as unparsed text. Separate,
+// pre-existing bug, out of scope here - not touching it in this PR.
+it("GET /api/geoJson/places/LOC5374Rome", () => {
+	cy.request({ url: "/api/geoJson/places/LOC5374Rome", failOnStatusCode: false }).then((res) => {
+		expect(res.status).to.eq(200);
+		expect(res.body).to.include('"id" : "LOC5374Rome"');
+		expect(res.body).to.include('"type" : "Feature"');
+	});
+});
+
+it("GET /api/geoJson/places/LIT1367Exodus (non-place id, empty but not an error)", () => {
 	cy.request({ url: "/api/geoJson/places/LIT1367Exodus", failOnStatusCode: false }).then((res) => {
 		expect(res.status).to.eq(200);
 	});


### PR DESCRIPTION
## Summary
- `places:json` (backing `/api/geoJson/places/{id}`) is now resolved dynamically by BetMasWeb's own Roaster router as a real routed operation (`operationId: places:json`), via a reusable cross-app lookup module - not a raw controller.xql forward anymore. Updated the doc comment to point at the actual mechanism so a future rename/move doesn't silently break BetMasWeb.
- Companion PR (the actual mechanism): BetaMasaheft/BetMasWeb#74
- Also includes the `coord:getCoords($id)` -> `coord:getCoords($uri)` fix (was #48, cherry-picked in here): `places:JSONfile` was passing the bare id instead of the full BMurl-prefixed uri `coord:getCoords` branches on, so coordinates/bbox/reprPoint always came back XPath `NaN` (not valid JSON). Fixes #47 (bug 1 of 2 - see that issue for the companion `wd:` CURIE fix, BetaMasaheft/BetMasWeb#75).

## Also fixed
- `places.cy.js`'s only test of this route used a work id (`LIT1367Exodus`, not LOC/INS/ETH), which always got an empty-but-200 response and never actually exercised real geoJSON generation. Switched to the `LOC5374Rome` fixture and asserted on content.

## Test plan
- [x] Verified `GET /api/geoJson/places/{id}` against a live rebuild of this repo's own `docker-compose.yml` (real corpus, real ids)
- [x] `npx cypress run --spec test/cypress/e2e/places.cy.js` passing against the live container
- [x] Verified end-to-end through BetMasWeb#74's Roaster/crossapp mechanism: BetMasApi installed -> real geoJSON; BetMasApi absent -> clean 501
- [x] `coord:getCoords($uri)` fix verified against a live container with a temporarily-real `$loc:appUrl` (see #47 for why that's necessary) - real coordinates, not NaN