### PR TITLE
fix: pass full uri to coord:getCoords, not bare id (#47)

### DIFF
--- a/local/places.xqm
+++ b/local/places.xqm
@@ -137,7 +137,11 @@ declare function places:JSONfile($item as node(), $id as xs:string) {
 		for $latlng in tokenize($item//t:geo[@rend eq "polygon"], "\n")
 		return replace(normalize-space($latlng), " ", ",")
 	) else
-		for $c in tokenize(coord:invertCoord(coord:getCoords($id)), ",")
+		(: coord:getCoords branches on a full BMurl-prefixed uri, not a bare
+		xml:id - passing $id here always misses every branch and falls through
+		to an external-gazetteer-ref lookup that can't match it either, so this
+		always produced XPath NaN (BetMasApi#47). :)
+		for $c in tokenize(coord:invertCoord(coord:getCoords($uri)), ",")
 		return number($c)
 	return map {
 		"@context":


### PR DESCRIPTION
## Summary
Fixes #47 (one of two compounding bugs - see issue for the other).

`coord:getCoords` (BetMasWeb, `modules/coordinates.xqm`) branches on whether its argument starts with the full BMurl-prefixed uri. `places:JSONfile` already builds that uri (`$uri`) one line above the call, but was passing the bare `$id` instead - every branch was missed, and `coordinates`/`bbox`/`reprPoint` always came back XPath `NaN`, which isn't valid JSON.

## Companion fix
BetaMasaheft/BetMasWeb#75 - `coord:GNorWD` doesn't recognize the `wd:` CURIE form `@sameAs` actually stores, so sameAs-only records (no direct `<geo>`) still need that fix too, on top of this one.

## A separate thing found while verifying
Neither this fix nor the companion one can be *proven* against this repo's own `docker-compose.yml` or CI as currently configured: `$config:appUrl` (BetMasWeb `modules/loc.xqm`) is a placeholder (`""`) by design, meant to be overwritten by a separate `betmas-init` deployment step that neither this repo's compose nor its CI workflow runs. 

## Test plan
- [x] `coord:getCoords($uri)` verified directly against a live container
- [x] End-to-end `GET /api/geoJson/places/{id}` verified with a temporarily-real `$loc:appUrl` - real coordinates, not NaN
- [x] Confirmed the fix alone is not sufficient for CI as currently configured (see above) - not a regression, a pre-existing gap